### PR TITLE
fix augassign which has no line number

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -600,10 +600,18 @@ class Interpreter:
 
     def on_augassign(self, node):    # ('target', 'op', 'value')
         """Augmented assign."""
+        line_info = {
+            'lineno': node.lineno,
+            'col_offset': node.col_offset,
+            'end_lineno': node.end_lineno,
+            'end_col_offset': node.end_col_offset
+        }
         return self.on_assign(ast.Assign(targets=[node.target],
                                          value=ast.BinOp(left=node.target,
                                                          op=node.op,
-                                                         right=node.value)))
+                                                         right=node.value,
+                                                         **line_info),
+                                                         **line_info))
 
     def on_slice(self, node):    # ():('lower', 'upper', 'step')
         """Simple slice."""

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -1645,5 +1645,17 @@ def test_naming_exceptions(nested):
     assert 'unsupported operand' in out
     assert len(interp.error) == 0
 
+@pytest.mark.parametrize("nested", [False, True])
+def test_augassign_lineno(nested):
+    """test lineno on augassign operation"""
+    interp = make_interpreter(nested_symtable=nested)
+
+    interp(textwrap.dedent("""
+    x = 1
+    x /= 0
+    """))
+    check_error(interp, 'ZeroDivisionError', 'x /= 0')
+    assert interp.error[0].lineno == 3
+
 if __name__ == '__main__':
     pytest.main(['-v', '-x', '-s'])


### PR DESCRIPTION
This pr added the missing lineno in augassign operation. The error message should be more precise with this fix.