### PR TITLE
Fix: comprehension loop variables leak into the symbol table(Fixes: #issue 155)

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -817,6 +817,7 @@ class Interpreter:
     def _comp_save_syms(self, node):
         """find and save symbols that will be used in a comprehension"""
         saved_syms = {}
+        delete_syms = set()
         for tnode in node.generators:
             # Extract all names from the target (handles nested tuples)
             names = self._extract_names_from_target(tnode.target)
@@ -826,7 +827,9 @@ class Interpreter:
                     self.raise_exception(tnode.target, exc=NameError, msg=errmsg)
                 if name in self.symtable:
                     saved_syms[name] = copy.deepcopy(self.symtable.get(name))
-        return saved_syms
+                else:
+                    delete_syms.add(name)
+        return saved_syms, delete_syms
 
 
     def do_generator(self, gnodes, node, out):
@@ -860,12 +863,14 @@ class Interpreter:
 
     def on_listcomp(self, node):
         """List comprehension v2"""
-        saved_syms = self._comp_save_syms(node)
+        saved_syms, delete_syms = self._comp_save_syms(node)
 
         out = []
         self.do_generator(node.generators, node, out)
         for name, val in saved_syms.items():
             self.symtable[name] = val
+        for name in delete_syms:
+            self.symtable.pop(name, None)
         return out
 
     def on_setcomp(self, node):
@@ -874,12 +879,14 @@ class Interpreter:
 
     def on_dictcomp(self, node):
         """Dict comprehension v2"""
-        saved_syms = self._comp_save_syms(node)
+        saved_syms, delete_syms = self._comp_save_syms(node)
 
         out = {}
         self.do_generator(node.generators, node, out)
         for name, val in saved_syms.items():
             self.symtable[name] = val
+        for name in delete_syms:
+            self.symtable.pop(name, None)
         return out
 
     def on_excepthandler(self, node):  # ('type', 'name', 'body')

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -876,6 +876,43 @@ def test_comprehension_tuple_unpacking(nested):
     isvalue(interp, 'result', [10, 26])
 
 @pytest.mark.parametrize("nested", [False, True])
+def test_comprehension_no_leak(nested):
+    """comprehension loop variables must not leak into the symbol table"""
+    interp = make_interpreter(nested_symtable=nested)
+
+    # new loop variable must not remain accessible
+    interp('x = [ti for ti in range(13)]')
+    isvalue(interp, 'x', list(range(13)))
+    assert 'ti' not in interp.symtable
+
+    # pre-existing symbol shadowed by comprehension must keep its value
+    interp('j = 42')
+    interp('y = [j*j for j in range(4)]')
+    isvalue(interp, 'y', [0, 1, 4, 9])
+    isvalue(interp, 'j', 42)
+
+    # tuple-unpacking targets are also cleaned up
+    interp('z = [a + b for a, b in [(1, 2), (3, 4)]]')
+    isvalue(interp, 'z', [3, 7])
+    assert 'a' not in interp.symtable
+    assert 'b' not in interp.symtable
+
+    # set and dict comprehensions too
+    interp('s = {k for k in range(3)}')
+    isvalue(interp, 's', {0, 1, 2})
+    assert 'k' not in interp.symtable
+
+    interp('d = {n: n*2 for n in range(3)}')
+    isvalue(interp, 'd', {0: 0, 1: 2, 2: 4})
+    assert 'n' not in interp.symtable
+
+    # nested generators: each loop variable is cleaned up
+    interp('m = [(i, j) for i in range(2) for j in range(3)]')
+    isvalue(interp, 'm', [(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)])
+    assert 'i' not in interp.symtable
+    assert 'j' not in interp.symtable
+
+@pytest.mark.parametrize("nested", [False, True])
 def test_ifexp(nested):
     """test if expressions"""
     interp = make_interpreter(nested_symtable=nested)

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -910,7 +910,7 @@ def test_comprehension_no_leak(nested):
     interp('m = [(i, j) for i in range(2) for j in range(3)]')
     isvalue(interp, 'm', [(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)])
     assert 'i' not in interp.symtable
-    assert 'j' not in interp.symtable
+    isvalue(interp, 'j', 42)
 
 @pytest.mark.parametrize("nested", [False, True])
 def test_ifexp(nested):


### PR DESCRIPTION
# Fix: comprehension loop variables leak into the symbol table(Fixes: #issue 155)

## Summary

Fixes the issue where loop variables used in list/set/dict comprehensions remain
accessible in the interpreter's symbol table after the comprehension finishes
executing. This deviates from standard Python (3.12+) behavior and pollutes the
namespace of long-running interpreters.

Fixes: [issue title: "Comprehension loop variable leaks into symbol table"]

## Bug Description

```python
from asteval import Interpreter

aeval = Interpreter()

aeval('[ti for ti in range(13)]')

result = aeval('ti')
print(result)  # prints 12 -- 'ti' should not be defined here
```

After `[ti for ti in range(13)]`, the loop variable `ti` remains in the symbol
table with its last assigned value (`12`). In CPython 3.12+, this raises
`NameError: name 'ti' is not defined`.

## Root Cause

asteval evaluates comprehensions against the same flat `symtable` dictionary
used for the rest of the program. The existing cleanup infrastructure in
`_comp_save_syms` only saves/restores comprehension target names that **already
existed** in the symbol table before the comprehension ran:

```python
if name in self.symtable:
    saved_syms[name] = copy.deepcopy(self.symtable.get(name))
```

Names that did not previously exist are neither saved nor recorded, so after the
comprehension assigns them via `_unpack_to_target` during iteration, they are
never removed.

## Proposed Fix (minimal)

Extend the existing save/restore machinery in `_comp_save_syms` to also record
which comprehension target names were **new** (not in the symbol table before
the comprehension). After the comprehension executes, restore pre-existing
values and delete the new names. This reuses the existing infrastructure and
does not introduce a new scoping mechanism.

### `asteval/asteval.py`

Change `_comp_save_syms` to return both the symbols to restore and the new
symbols to delete:

```python
def _comp_save_syms(self, node):
    """find and save symbols that will be used in a comprehension"""
    saved_syms = {}
    delete_syms = set()
    for tnode in node.generators:
        # Extract all names from the target (handles nested tuples)
        names = self._extract_names_from_target(tnode.target)
        for name in names:
            if not valid_symbol_name(name) or name in self.readonly_symbols:
                errmsg = f"invalid symbol name (reserved word?) {name}"
                self.raise_exception(tnode.target, exc=NameError, msg=errmsg)
            if name in self.symtable:
                saved_syms[name] = copy.deepcopy(self.symtable.get(name))
            else:
                delete_syms.add(name)
    return saved_syms, delete_syms
```

Update `on_listcomp`:

```python
def on_listcomp(self, node):
    """List comprehension"""
    saved_syms, delete_syms = self._comp_save_syms(node)

    out = []
    self.do_generator(node.generators, node, out)
    for name, val in saved_syms.items():
        self.symtable[name] = val
    for name in delete_syms:
        self.symtable.pop(name, None)
    return out
```

Update `on_dictcomp`:

```python
def on_dictcomp(self, node):
    """Dict comprehension"""
    saved_syms, delete_syms = self._comp_save_syms(node)

    out = {}
    self.do_generator(node.generators, node, out)
    for name, val in saved_syms.items():
        self.symtable[name] = val
    for name in delete_syms:
        self.symtable.pop(name, None)
    return out
```

(`on_setcomp` delegates to `on_listcomp`, so it is automatically covered.)

## Why This Is Not Over-Engineered

- Reuses the existing `_comp_save_syms` save/restore pattern — no temporary
  scope objects, symbol-table swapping, or AST rewriting are introduced.
- Only ~6 small lines change: one `delete_syms` collector in `_comp_save_syms`,
  a returned tuple, and a short cleanup loop in each of the two comprehension
  handlers.
- Pre-existing symbols keep their exact old values (deep-copied and restored),
  preserving the current shadowing semantics during comprehension execution.

## Tests

Add regression tests asserting that a comprehension loop variable is not
accessible after evaluation, while a pre-existing symbol shadowed by a
comprehension retains its original value:

```python
# tests/test_asteval.py
@pytest.mark.parametrize("nested", [False, True])
def test_comprehension_no_leak(nested):
    """comprehension loop variables must not leak into the symbol table"""
    interp = make_interpreter(nested_symtable=nested)

    # new loop variable must not remain accessible
    interp('x = [ti for ti in range(13)]')
    isvalue(interp, 'x', list(range(13)))
    assert 'ti' not in interp.symtable

    # pre-existing symbol shadowed by comprehension must keep its value
    interp('j = 42')
    interp('y = [j*j for j in range(4)]')
    isvalue(interp, 'y', [0, 1, 4, 9])
    isvalue(interp, 'j', 42)

    # tuple-unpacking targets are also cleaned up
    interp('z = [a + b for a, b in [(1, 2), (3, 4)]]')
    isvalue(interp, 'z', [3, 7])
    assert 'a' not in interp.symtable
    assert 'b' not in interp.symtable
```

## Verification

- Existing comprehension tests (`test_list_comprehension`,
  `test_list_comprehension_more`, `test_set_comprehension`,
  `test_dict_comprehension`, `test_comprehension_tuple_unpacking`) continue to
  pass unchanged.
- New regression test above passes for both flat and nested symbol tables.