### PR TITLE
Reject unsafe attribute assignments

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -46,7 +46,7 @@ from sys import exc_info, stderr, stdout
 
 from .astutils import (HAS_NUMPY, ExceptionHolder, ReturnedNone,
                        Empty, make_symbol_table, op2func,
-                       safe_getattr, safe_format, valid_symbol_name,
+                       safe_getattr, safe_setattr, safe_format, valid_symbol_name,
                        Procedure)
 
 ALL_NODES = ['arg', 'assert', 'assign', 'attribute', 'augassign',
@@ -575,7 +575,8 @@ class Interpreter:
                 msg = f"cannot assign to attribute {node.attr}"
                 self.raise_exception(node, exc=AttributeError, msg=msg)
 
-            setattr(self.run(node.value), node.attr, val)
+            safe_setattr(self.run(node.value), node.attr, val,
+                         self.raise_exception, node)
 
         elif node.__class__ == ast.Subscript:
             self.run(node.value)[self.run(node.slice)] = val

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -279,7 +279,7 @@ OPERATORS = {ast.Is: lambda a, b: a is b,
              ast.UAdd: lambda a: +a,
              ast.USub: lambda a: -a}
 
-# Safe version of getattr
+# Safe versions of getattr and setattr
 
 def safe_getattr(obj, attr, raise_exc, node, allow_unsafe_modules=False):
     """safe version of getattr"""
@@ -300,6 +300,13 @@ def safe_getattr(obj, attr, raise_exc, node, allow_unsafe_modules=False):
         raise_exc(node, exc=AttributeError, msg=msg)
     else:
         return getattr(obj, attr, None)
+
+def safe_setattr(obj, attr, val, raise_exc, node):
+    """safe version of setattr"""
+    if attr in UNSAFE_ATTRS or (attr.startswith('__') and attr.endswith('__')):
+        msg = f"cannot assign to unsafe attribute {attr}"
+        raise_exc(node, exc=AttributeError, msg=msg)
+    setattr(obj, attr, val)
 
 class SafeFormatter(Formatter):
     def __init__(self, raise_exc, node):

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -12,6 +12,7 @@ from functools import partial
 from io import StringIO
 from sys import version_info
 from tempfile import NamedTemporaryFile
+from types import SimpleNamespace
 
 import pytest
 
@@ -589,6 +590,20 @@ def test_assignment(nested):
         isvalue(interp, "a", np.arange(10))
         interp('a[1:5] = 1 + 0.5 * arange(4)')
         isnear(interp, "a", np.array([0., 1., 1.5, 2., 2.5, 5., 6., 7., 8., 9.]))
+
+
+@pytest.mark.parametrize("nested", [False, True])
+@pytest.mark.parametrize("attr", ["__private__", "func_globals"])
+def test_unsafe_attribute_assignment(nested, attr):
+    """unsafe attribute assignment"""
+    obj = SimpleNamespace()
+    sym_table = make_symbol_table(nested=nested, obj=obj)
+    interp = Interpreter(symtable=sym_table)
+    interp(f"obj.{attr} = 1", show_errors=False)
+    check_error(interp, 'AttributeError',
+                f'cannot assign to unsafe attribute {attr}')
+    assert not hasattr(obj, attr)
+
 
 @pytest.mark.parametrize("nested", [False, True])
 def test_names(nested):


### PR DESCRIPTION
Attribute reads already use `safe_getattr` to reject dunder attributes and names listed in `UNSAFE_ATTRS`. This change applies the same policy to attribute assignments through a new `safe_setattr` helper.
